### PR TITLE
Implement Typescript path aliases (Fixes #7)

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -5,4 +5,8 @@ module.exports = {
   },
   testRegex: '(/tests/.*|(\\.|/)(test|spec))\\.ts?$',
   moduleFileExtensions: ['ts', 'js', 'json'],
+  moduleNameMapper: {
+    "@validators/(.*)": "<rootDir>/src/validators/$1",
+    "@src/(.*)": "<rootDir>/src/$1",
+  }
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -5353,6 +5353,11 @@
         "minimist": "^1.2.5"
       }
     },
+    "module-alias": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/module-alias/-/module-alias-2.2.2.tgz",
+      "integrity": "sha512-A/78XjoX2EmNvppVWEhM2oGk3x4lLxnkEA4jTbaK97QKSDjkIoOsKQlfylt/d3kKKi596Qy3NP5XrXJ6fZIC9Q=="
+    },
     "ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,11 @@
     "typescript": "^4.0.3"
   },
   "dependencies": {
-    "diacritics": "^1.3.0"
+    "diacritics": "^1.3.0",
+    "module-alias": "^2.2.2"
+  },
+  "_moduleAliases": {
+	  "@validators": "dist/validators",
+	  "@src": "dist"
   }
 }

--- a/src/HandyValidator.ts
+++ b/src/HandyValidator.ts
@@ -1,15 +1,16 @@
+import 'module-alias/register';
 import { IValidation, IHandyValidatorPlugin, IHandyValidator } from './interfaces';
 import { HandyValidatorPlugin } from './HandyValidatorPlugin';
 
-import { ArrayValidator } from './validators/array';
-import { BooleanValidator } from './validators/boolean';
-import { EqualToValidator } from './validators/equalTo';
-import { NullValidator } from './validators/null';
-import { NumberValidator } from './validators/number';
-import { ObjectValidator } from './validators/object';
-import { PalindromeValidator } from './validators/palindrome';
-import { StringValidator } from './validators/string';
-import { UndefinedValidator } from './validators/undefined';
+import { ArrayValidator } from '@validators/array';
+import { BooleanValidator } from '@validators/boolean';
+import { EqualToValidator } from '@validators/equalTo';
+import { NullValidator } from '@validators/null';
+import { NumberValidator } from '@validators/number';
+import { ObjectValidator } from '@validators/object';
+import { PalindromeValidator } from '@validators/palindrome';
+import { StringValidator } from '@validators/string';
+import { UndefinedValidator } from '@validators/undefined';
 
 /**
  * Handy Validator

--- a/src/HandyValidatorPlugin.ts
+++ b/src/HandyValidatorPlugin.ts
@@ -1,5 +1,5 @@
 /* eslint-disable class-methods-use-this */
-import { IHandyValidatorPlugin, IValidation } from './interfaces';
+import { IHandyValidatorPlugin, IValidation } from '@src/interfaces';
 
 export class HandyValidatorPlugin implements IHandyValidatorPlugin {
   validate(value: unknown, ...args: unknown[]): boolean {

--- a/src/validators/array/index.ts
+++ b/src/validators/array/index.ts
@@ -1,4 +1,4 @@
-import { HandyValidatorPlugin } from '../../HandyValidatorPlugin';
+import { HandyValidatorPlugin } from '@src/HandyValidatorPlugin';
 import { IOperatorArguments, IOperatorClasses } from './interfaces';
 
 import { EqualToArrayOperator } from './operators/EqualTo';

--- a/src/validators/boolean/index.ts
+++ b/src/validators/boolean/index.ts
@@ -1,4 +1,4 @@
-import { HandyValidatorPlugin } from '../../HandyValidatorPlugin';
+import { HandyValidatorPlugin } from '@src/HandyValidatorPlugin';
 
 /**
  * Boolean validator

--- a/src/validators/equalTo/index.ts
+++ b/src/validators/equalTo/index.ts
@@ -1,4 +1,4 @@
-import { HandyValidatorPlugin } from '../../HandyValidatorPlugin';
+import { HandyValidatorPlugin } from '@src/HandyValidatorPlugin';
 
 /**
  * equalTo Validator

--- a/src/validators/null/index.ts
+++ b/src/validators/null/index.ts
@@ -1,4 +1,4 @@
-import { HandyValidatorPlugin } from '../../HandyValidatorPlugin';
+import { HandyValidatorPlugin } from '@src/HandyValidatorPlugin';
 
 /**
  * Null validator

--- a/src/validators/number/index.ts
+++ b/src/validators/number/index.ts
@@ -1,4 +1,4 @@
-import { HandyValidatorPlugin } from '../../HandyValidatorPlugin';
+import { HandyValidatorPlugin } from '@src/HandyValidatorPlugin';
 import { IOperatorArguments, IOperatorClasses } from './interfaces';
 
 import { EqualToNumberOperator } from './operators/EqualTo';

--- a/src/validators/object/index.ts
+++ b/src/validators/object/index.ts
@@ -1,4 +1,4 @@
-import { HandyValidatorPlugin } from '../../HandyValidatorPlugin';
+import { HandyValidatorPlugin } from '@src/HandyValidatorPlugin';
 
 /**
  * Object Validator

--- a/src/validators/palindrome/index.ts
+++ b/src/validators/palindrome/index.ts
@@ -1,4 +1,4 @@
-import { HandyValidatorPlugin } from '../../HandyValidatorPlugin';
+import { HandyValidatorPlugin } from '@src/HandyValidatorPlugin';
 import { IPalindrome } from './interfaces';
 import { PalindromeNumber } from './PalindromeNumber';
 import { PalindromeString } from './PalindromeString';

--- a/src/validators/string/index.ts
+++ b/src/validators/string/index.ts
@@ -1,4 +1,4 @@
-import { HandyValidatorPlugin } from '../../HandyValidatorPlugin';
+import { HandyValidatorPlugin } from '@src/HandyValidatorPlugin';
 import { IOperatorArguments, IOperatorClasses } from './interfaces';
 
 import { EqualToStringOperator } from './operators/EqualTo';

--- a/src/validators/undefined/index.ts
+++ b/src/validators/undefined/index.ts
@@ -1,4 +1,4 @@
-import { HandyValidatorPlugin } from '../../HandyValidatorPlugin';
+import { HandyValidatorPlugin } from '@src/HandyValidatorPlugin';
 
 /**
  * Undefined validator

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,12 @@
     "strict": true,
     "esModuleInterop": true,
     "outDir": "dist",
-    "moduleResolution": "node"
+    "moduleResolution": "node",
+	"baseUrl": "./src",
+	"paths": {
+		"@validators/*": ["validators/*"],
+		"@src/*": ["*"]
+	}
   },
   "include": [
     "src/HandyValidator.ts"


### PR DESCRIPTION
Following [this guide](https://dev.to/larswaechter/path-aliases-with-typescript-in-nodejs-4353) and the [official docs](https://www.typescriptlang.org/docs/handbook/module-resolution.html), I was able to add two path aliases: `@validators/` pointing to `src/validators/`, and `@src/` pointing to `src/`.

It's worth testing this in another lib that lists it as a dependency -- the `module-alias` package is supposed to handle the runtime alias resolution, since Typescript doesn't appear to do a string substitution to sorta "compile them away".